### PR TITLE
Fix build for Ubuntu 16.04 & NodeJS >= 8

### DIFF
--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -212,16 +212,17 @@ namespace crypto {
 
 PUSH_WARNINGS
 DISABLE_VS_WARNINGS(4200)
+  struct ec_point_pair {
+    ec_point a, b;
+  };
   struct rs_comm {
     hash h;
-    struct {
-      ec_point a, b;
-    } ab[];
-  };
+    struct ec_point_pair ab[];
+  } ;
 POP_WARNINGS
 
   static inline size_t rs_comm_size(size_t pubs_count) {
-    return sizeof(rs_comm) + pubs_count * sizeof(rs_comm().ab[0]);
+    return sizeof(rs_comm) + pubs_count * sizeof(ec_point_pair);
   }
 
   void crypto_ops::generate_ring_signature(const hash &prefix_hash, const key_image &image,

--- a/src/cryptonote_core/cryptonote_format_utils.cpp
+++ b/src/cryptonote_core/cryptonote_format_utils.cpp
@@ -933,8 +933,4 @@ namespace cryptonote
     return true;
   }
   //---------------------------------------------------------------
-  bool check_proof_of_work(const block& bl, difficulty_type current_diffic, crypto::hash& proof_of_work)
-  {
-  }
-  //---------------------------------------------------------------
 }

--- a/src/cryptonote_core/cryptonote_format_utils.h
+++ b/src/cryptonote_core/cryptonote_format_utils.h
@@ -209,7 +209,6 @@ namespace cryptonote
 
   bool check_proof_of_work_v1(const block& bl, difficulty_type current_diffic, crypto::hash& proof_of_work);
   bool check_proof_of_work_v2(const block& bl, difficulty_type current_diffic, crypto::hash& proof_of_work);
-  bool check_proof_of_work(const block& bl, difficulty_type current_diffic, crypto::hash& proof_of_work);
 
 #define CHECKED_GET_SPECIFIC_VARIANT(variant_var, specific_type, variable_name, fail_return_val) \
   CHECK_AND_ASSERT_MES(variant_var.type() == typeid(specific_type), fail_return_val, "wrong variant type: " << variant_var.type().name() << ", expected " << typeid(specific_type).name()); \


### PR DESCRIPTION
Hey @Snipa22, this merge request fixes the build when using Ubuntu 16.04 and NodeJS >= 8.

Without this fix, it prevents us to use a recent version of NodeJS with nodejs-pool.

Changes in `crypto.cpp` are implemented the same way the Monero project implemented it.
I removed an empty function which was generating compile warnings.
